### PR TITLE
Update Login.vue

### DIFF
--- a/src/components/Login.vue
+++ b/src/components/Login.vue
@@ -123,6 +123,9 @@
             login() {
                 this.performingRequest = true
 
+                // on v5 or later of the Firebase SDK, use:
+				// fb.auth.signInWithEmailAndPassword(this.loginForm.email, this.loginForm.password).then(credentials => {
+                //    let user = credentials.user
                 fb.auth.signInWithEmailAndPassword(this.loginForm.email, this.loginForm.password).then(user => {
                     this.$store.commit('setCurrentUser', user)
                     this.$store.dispatch('fetchUserProfile')


### PR DESCRIPTION
There was a breaking change in v5 of the Firebase Authentication SDK. Many developers use this code, but are then confused about errors when `user.uid` doesn't exist. I proposed a comment here, but an alternative is to use code that works in both cases, e.g.:

     if (user && !user.uid) user = user.user;

It's a bit cryptic, but pulls the `user` from within the `AuthCredential` if needed.