### PR TITLE
Add space before function parentheses

### DIFF
--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -59,7 +59,7 @@ export default {
   components: {
     PasswordReset
   },
-  data() {
+  data () {
     return {
       loginForm: {
         email: '',


### PR DESCRIPTION
Fixes a linter error "Missing space before function parentheses  space-before-function-paren"